### PR TITLE
Shield to damage correlating

### DIFF
--- a/Neverwinter.cs
+++ b/Neverwinter.cs
@@ -16,10 +16,12 @@ using System.Net;
 [assembly: AssemblyTitle("Neverwinter Parsing Plugin")]
 [assembly: AssemblyDescription("A basic parser that reads the combat logs in Neverwinter.")]
 [assembly: AssemblyCopyright("nils.brummond@gmail.com based on: Antday <Unique> based on STO Plugin from Hilbert@mancom, Pirye@ucalegon")]
-[assembly: AssemblyVersion("1.0.0.0")]
+[assembly: AssemblyVersion("1.0.1.0")]
 
 
 /* Version History - npb
+ * 1.1.0.0 - 2013/9/2X
+ *  - Improvements to shield tracking.  Matches shield to damage and adds extra info.
  * 1.0.0.0 - 2013/9/26
  *  - Fixes to shield tracking.
  *  - Fixes to Chaotic Growth tracking.
@@ -1733,6 +1735,8 @@ namespace NWParsing_Plugin
             if (msShielded != null)
             {
                 // Fix up the shield line.
+                // Tags are about the only thing that can be altered on MS that is already added via AddCombatAction.
+                // So do most of it with adding Tags.
 
                 object val;
                 if (msShielded.Tags.TryGetValue("DamageF", out val))
@@ -2317,15 +2321,6 @@ namespace NWParsing_Plugin
 
         public MasterSwing MatchDamage(ParsedLine line)
         {
-            
-            if (active.Count > 30)
-            {
-                // BAD
-                active.Clear();
-                return null;
-            }
-            
-
             LinkedListNode<ShieldLine> slnNext = active.First;
 
             while (slnNext != null)

--- a/Neverwinter.cs
+++ b/Neverwinter.cs
@@ -1738,6 +1738,9 @@ namespace NWParsing_Plugin
                 // Tags are about the only thing that can be altered on MS that is already added via AddCombatAction.
                 // So do most of it with adding Tags.
 
+                // Shield line:  add column for attack damage and % blocked
+                // Attack line:  add amount shielded to the 'special' column.
+
                 object val;
                 if (msShielded.Tags.TryGetValue("DamageF", out val))
                 {
@@ -2298,7 +2301,8 @@ namespace NWParsing_Plugin
 
     internal class UnmatchedShieldLines
     {
-        // Added new lines to end to maintain FIFO ordering.
+        // Added new lines to end to maintain FIFO/Time ordering.
+        // Should act as a FIFO if 100% matches.
         private LinkedList<ShieldLine> active = new LinkedList<ShieldLine>();
 
         public UnmatchedShieldLines()
@@ -2356,6 +2360,8 @@ namespace NWParsing_Plugin
 
                     if (diff.TotalMilliseconds > 500)
                     {
+                        // Drop old and unmatch shield lines.
+                        // Generally shield line should match in <= 100ms.
                         active.Remove(cur);
                     }
                 }

--- a/README.md
+++ b/README.md
@@ -26,6 +26,8 @@ Known Issues
 ============
 - Devoted Cleric power "Flame Strike" causes falling damage that can not be tracked.  Falling damage does not specify who/what caused the fall.
 - There is currently no way to detect zone changes from the Combatlog.Log file.
+- When updating your plugin you may get a "plugin initialization failed" error.  The workaround is to remove the old plugin, restart ACT, and add the new plugin.
+- injuries are counted as outgoing damage.  (Feature?)
 
 
 Install

--- a/README.md
+++ b/README.md
@@ -12,6 +12,7 @@ which is based on the STO plugin from Hilbert @ mancom, Pirye @ ucalegon.
 
 State
 =====
+- Imporved GW shieldblock tracking.  See new optional columns (DmgToShield, ShieldP)
 - Stable enough for a 1.0 release.  Please report any issues you have.
 - Tracking of CW Chaotic Growth gives the healing credit to the last CW to MM the target.
 - Most special cases should be covered now.


### PR DESCRIPTION
Matches damage to shield line.
Adds two new optional columns (DmgToShield and ShieldP) for looking at shielding of a GW.
- DmgToShield: The amount of damage done by the attack being shielded.
- ShieldP: The percent of the incoming damage of the attack that was shielded.
